### PR TITLE
Changed license short identifier to 'LGPL-2.1'

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=The IoT Guru integration
 version=1.1.0
 author=The IoT Guru (info@iotguru.live)
-license=CC-LGPL 2.1
+license=LGPL-2.1
 maintainer=Gábor AUTH (gabor.auth@iotguru.live)
 sentence=Cloud and Android frontend support to your devices
 paragraph=Real time charts, device catalog, data store with backup, battery and offline alert, MQTT broker, HTTP REST support, Android and web client.


### PR DESCRIPTION
The license field in library.properties needs to be a valid SPDX short identifier