### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,25 +10,25 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setCallback                    KEYWORD2
-setCheckDuration               KEYWORD2
-setDebugPrinter                KEYWORD2
-setNetworkClient               KEYWORD2
+setCallback	KEYWORD2
+setCheckDuration	KEYWORD2
+setDebugPrinter	KEYWORD2
+setNetworkClient	KEYWORD2
 
-check                          KEYWORD2
-loop                           KEYWORD2
+check	KEYWORD2
+loop	KEYWORD2
 
-sendHttpValue                  KEYWORD2
-sendMqttValue                  KEYWORD2
+sendHttpValue	KEYWORD2
+sendMqttValue	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-IoTGuru                        KEYWORD2
+IoTGuru	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-IOT_GURU_CLIENT_VERSION        LITERAL1
+IOT_GURU_CLIENT_VERSION	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords